### PR TITLE
Fix QueryID and add tests

### DIFF
--- a/pkg/api/rest/rerr/rerr.go
+++ b/pkg/api/rest/rerr/rerr.go
@@ -69,7 +69,7 @@ func Path[T any](ctx *gin.Context, name string) (id.ID[T], bool) {
 }
 
 func QueryID[T any](ctx *gin.Context, name string) (id.ID[T], bool) {
-	rawID := ctx.Param(name)
+	rawID := ctx.Query(name)
 
 	uuidID, err := uuid.Parse(rawID)
 	if err != nil {

--- a/pkg/api/rest/rerr/rerr_test.go
+++ b/pkg/api/rest/rerr/rerr_test.go
@@ -1,0 +1,62 @@
+package rerr_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"go-backend/pkg/api/rest/rerr"
+)
+
+func TestQueryID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("valid query id", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		idStr := uuid.NewString()
+		ctx.Request = httptest.NewRequest("GET", "/?id="+idStr, nil)
+
+		id, ok := rerr.QueryID[struct{}](ctx, "id")
+		require.True(t, ok)
+		require.Equal(t, idStr, id.UUID.String())
+	})
+
+	t.Run("invalid query id", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest("GET", "/?id=invalid", nil)
+
+		id, ok := rerr.QueryID[struct{}](ctx, "id")
+		require.False(t, ok)
+		require.Equal(t, uuid.Nil, id.UUID)
+	})
+}
+
+func TestPathID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("valid path id", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		idStr := uuid.NewString()
+		ctx.Params = gin.Params{gin.Param{Key: "id", Value: idStr}}
+
+		id, ok := rerr.PathID[struct{}](ctx)
+		require.True(t, ok)
+		require.Equal(t, idStr, id.UUID.String())
+	})
+
+	t.Run("invalid path id", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Params = gin.Params{gin.Param{Key: "id", Value: "invalid"}}
+
+		id, ok := rerr.PathID[struct{}](ctx)
+		require.False(t, ok)
+		require.Equal(t, uuid.Nil, id.UUID)
+	})
+}


### PR DESCRIPTION
## Summary
- parse IDs from query parameters correctly
- add tests for QueryID and PathID helpers

## Testing
- `go test ./...`
- `go test ./pkg/api/rest/rerr -run TestQueryID -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6849fde8f5b88332b9d8dfbef81e3105